### PR TITLE
🎉 支持在 Markdown 中通过 Shortcode 引用 图标和图片

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/fordes123/hugo-theme-item
 go 1.20
 
 require (
-	github.com/KaTeX/KaTeX v0.16.11 // indirect
+	github.com/KaTeX/KaTeX v0.16.15 // indirect
 	github.com/hugomods/font-awesome v6.7.1+incompatible // indirect
 	github.com/hugomods/hugopress v0.5.0 // indirect
 	github.com/hugomods/icons v0.6.6 // indirect
 	github.com/hugomods/icons/vendors/font-awesome v0.6.12 // indirect
 	github.com/hugomods/icons/vendors/lucide v0.3.40 // indirect
-	github.com/hugomods/katex v0.3.3 // indirect
+	github.com/hugomods/katex v0.3.4 // indirect
 	github.com/hugomods/lucide-icons v0.331.0 // indirect
 )

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
                     <h1 class="flex items-center justify-center gap-2 text-center text-3xl lg:text-4xl break-words w-full px-10 lg:px-30">
                         {{ if ne .Params.internal true }}
                             <!--@formatter:off-->
-                            {{ partial "utils/favicon" (dict "url" .Params.link "favicon" .Params.favicon "class" "avatar rounded-full object-contain h-[1em]" "alt" .Title) }}
+                            {{ partial "utils/favicon" (dict "link" .Params.link "favicon" .Params.favicon "class" "avatar rounded-full object-contain h-[1em]" "alt" .Title) }}
                             <!--@formatter:on-->
                         {{ end }}
                         {{ .Title }}</h1>

--- a/layouts/partials/component/carousel.html
+++ b/layouts/partials/component/carousel.html
@@ -5,7 +5,7 @@
         <div id="carousel-{{ $index }}" class="carousel-item relative w-full h-full transition-opacity duration-500 ease-in-out">
             <a href="{{ $item.url }}" target="_blank" class="w-full h-full">
                 <div class="w-full h-full flex items-center justify-center relative">
-                    {{ partial "utils/favicon" (dict "favicon" $item.img "class" "w-full h-full object-cover")}}
+                    {{ partial "utils/img" (dict "path" $item.img "class" "w-full h-full object-cover")}}
                     <div class="absolute inset-0 bg-gradient-to-t to-transparent"></div>
                     <div class="w-full h-1/3 absolute bottom-0 left-0 right-0 px-4 pb-4">
                         <h2 class="font-bold text-gray-200 text-left text-lg flex items-center h-full">{{ $item.name }}</h2>

--- a/layouts/partials/component/nav-block-item.html
+++ b/layouts/partials/component/nav-block-item.html
@@ -19,7 +19,7 @@
                 <a href="{{ .Permalink }}" class="block relative">
                     <div class="avatar rounded-full w-10 h-10 sm:w-12 sm:h-12 z-20">
                         <!--@formatter:off-->
-                        {{ partial "utils/favicon" (dict "url" .Params.link "favicon" .Params.favicon "class" "rounded-full object-contain" "alt" .Title) }}
+                        {{ partial "utils/favicon" (dict "link" .Params.link "favicon" .Params.favicon "class" "rounded-full object-contain" "alt" .Title) }}
                         <!--@formatter:on-->
                     </div>
                     {{ if (.Params.internal) }}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -2,7 +2,7 @@
     <aside class="">
         <div class="flex flex-col items-center justify-center mb-4">
             <!--@formatter:off-->
-            {{ partial "utils/favicon" (dict "favicon" .Site.Params.favicon "class" "h-12 w-12") }}
+            {{ partial "utils/img" (dict "path" .Site.Params.favicon "class" "h-12 w-12") }}
             <!--@formatter:on-->
         </div>
 

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -14,11 +14,11 @@
                    class="flex-0 btn btn-ghost gap-1 px-2 md:gap-2">
                    {{ if .Site.Params.logo }}
                         <!--@formatter:off-->
-                        {{ partial "utils/favicon" (dict "favicon" .Site.Params.logo "class" "h-full w-full object-contain p-2") }}
+                        {{ partial "utils/img" (dict "path" .Site.Params.logo "class" "h-full w-full object-contain p-2") }}
                         <!--@formatter:on-->
                    {{ else }}
                         <!--@formatter:off-->
-                        {{ partial "utils/icon" (dict "name" "favicon.ico" "class" "h-6 w-6 md:h-8 md:w-8") }}
+                        {{ partial "utils/img" (dict "path" "favicon.ico" "class" "h-6 w-6 md:h-8 md:w-8") }}
                         <!--@formatter:on-->
                         <span class="font-title text-base-content font-serif from-neutral-700 text-xl md:text-2xl">{{ .Site.Title }}</span>
                     {{ end }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,11 +7,11 @@
             <a href="{{ .Site.BaseURL | relURL }}" aria-current="page" aria-label="Homepage" class="flex-0 btn btn-ghost px-2 w-full">
                 {{ if .Site.Params.logo }}
                     <!--@formatter:off-->
-                    {{ partial "utils/favicon" (dict "favicon" .Site.Params.logo "class" "h-full w-full object-contain") }}
+                    {{ partial "utils/img" (dict "path" .Site.Params.logo "class" "h-full w-full object-contain") }}
                     <!--@formatter:on-->
                 {{ else }}
                     <!--@formatter:off-->
-                    {{ partial "utils/icon" (dict "name" "favicon.ico" "class" "h-6 w-6") }}
+                    {{ partial "utils/img" (dict "path" .Site.Params.favicon "class" "h-6 w-6") }}
                     <!--@formatter:on-->
                     <div class="font-title inline-flex font-serif from-neutral-700 text-xl md:text-2xl">{{ .Site.Title }}</div>
                 {{ end }}

--- a/layouts/partials/utils/favicon.html
+++ b/layouts/partials/utils/favicon.html
@@ -1,28 +1,16 @@
-{{ $url := .url }}
+<!-- 网址导航 favicon 图片获取 -->
+<!-- 
+    1. 如果传入 favicon 则直接使用传入的 favicon
+    2. 如果传入 link 则通过 https://favicon.im/ 自动获取 link 的 favicon
+ -->
+
+{{ $link := .link }}
 {{ $favicon := .favicon }}
 {{ $class := .class }}
 {{ $alt := .alt }}
 
 {{ if and $favicon (ne $favicon "") }}
-    {{ if hasPrefix $favicon "/" }}
-        <img src="{{ $favicon }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-    {{ else if or (hasPrefix $favicon "http://") (hasPrefix $favicon "https://") }}
-        <img src="{{ $favicon | safeHTML }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-    {{ else }}
-        {{ $localFavicon := resources.Get $favicon }}
-        {{ if $localFavicon }}
-            <img src="{{ $localFavicon.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-        {{ else }}
-            {{ $loadingGif := resources.Get "images/loading.gif" }}
-            <img src="{{ $loadingGif.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-        {{ end }}
-    {{ end }}
+    {{ partial "utils/img" (dict "path" $favicon "favicon" false "class" $class "alt" $alt) }}
 {{ else }}
-    {{ $host := (urls.Parse $url).Host }}
-    {{ if $host }}
-        <img src="https://favicon.im/{{ $host }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-    {{ else }}
-        {{ $loadingGif := resources.Get "images/loading.gif" }}
-        <img src="{{ $loadingGif.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
-    {{ end }}
+    {{ partial "utils/img" (dict "path" $link "favicon" true "class" $class "alt" $alt) }}
 {{ end }}

--- a/layouts/partials/utils/img.html
+++ b/layouts/partials/utils/img.html
@@ -1,0 +1,30 @@
+{{ $url := .path }}
+{{ $class := .class }}
+{{ $alt := .alt }}
+{{ $favicon := .favicon | default false }}
+
+{{ if and $url (ne $url "") }}
+    {{ if $favicon }}
+        {{ $host := (urls.Parse $url).Host }}
+        {{ if $host }}
+            <img src="https://favicon.im/{{ $host }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+        {{ else }}
+            {{ $loadingGif := resources.Get "images/loading.gif" }}
+            <img src="{{ $loadingGif.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+        {{ end }}
+    {{ else }}
+        {{ if hasPrefix $url "/" }}
+            <img src="{{ $url }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+        {{ else if or (hasPrefix $url "http://") (hasPrefix $url "https://") }}
+            <img src="{{ $url | safeHTML }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+        {{ else }}
+            {{ $localFavicon := resources.Get $url }}
+            {{ if $localFavicon }}
+                <img src="{{ $localFavicon.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+            {{ else }}
+                {{ $loadingGif := resources.Get "images/loading.gif" }}
+                <img src="{{ $loadingGif.RelPermalink }}" class="{{ $class | safeHTML }}" loading="lazy" alt="{{ $alt | safeHTML }}"/>
+            {{ end }}
+        {{ end }}
+    {{ end }}
+{{ end }}

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -1,0 +1,1 @@
+{{ partial "utils/icon" (dict "name" (.Get 0) "class" (.Get 1)) }}

--- a/layouts/shortcodes/img.html
+++ b/layouts/shortcodes/img.html
@@ -1,0 +1,1 @@
+{{ partial "utils/img" (dict "path" (.Get 0)  "class" (.Get 1) "alt" (.Get 2) "favicon" (.Get 3 | default false) ) }}


### PR DESCRIPTION
示例如下：

```markdown
<!-- 引用 hugo-mod 图标 -->
{{< icon lucide-info "h-12 w-12 text-primary" >}}

<!-- 引用 hugo-mod 图标（原生）-->
{{< icons/icon vendor=fas name=book color=red >}}

<!-- 嵌入指定图片 -->
{{< img "https://www.vercel.com/favicon.ico" "h-12 w-12" >}}

<!-- 嵌入指定网站 favicon -->
{{< img "https://www.github.com" "h-12 w-12" "Github Logo" "true" >}}
```